### PR TITLE
Fix docs site not rendering

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-docs.rugsafe.io

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -5,14 +5,14 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'RugSafe Documentation',
   tagline: 'A Multichain Protocol for Recovering from and Defending against Rug Pulls',
-  favicon: 'img/rugsafe_character_black_background.png',
+  favicon: 'img/rugsafe.png',
 
   // Set the production url of your site here
-  url: 'https://docs.rugsafe.com',
-  baseUrl: '/rugsafe-docs', // was /
+  url: 'https://docs.rugsafe.io',
+  baseUrl: '/',
 
-  organizationName: 'rugsafe',
-  projectName: 'rugsafedocs',
+  organizationName: 'Rugsafe',
+  projectName: 'rugsafe-docs',
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
@@ -28,7 +28,7 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.ts',
-          editUrl: 'https://github.com/rugsafe/rugsafedocs/tree/main/',
+          editUrl: 'https://github.com/Rugsafe/rugsafe-docs/tree/main/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -38,7 +38,7 @@ const config: Config = {
   ],
 
   themeConfig: {
-    image: 'img/rugsafe-social-card.jpg',
+    image: 'img/rugsafe_logo_black_background_with_text.png',
     navbar: {
       title: '',
       logo: {
@@ -53,7 +53,7 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://github.com/rugsafe/rugsafedocs',
+          href: 'https://github.com/Rugsafe/rugsafe-docs',
           label: 'GitHub',
           position: 'right',
         },
@@ -89,7 +89,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/rugsafe/rugsafedocs',
+              href: 'https://github.com/Rugsafe/rugsafe-docs',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- **Fixed `url`**: Changed from `https://docs.rugsafe.com` to `https://docs.rugsafe.io` to match the actual CNAME/domain
- **Fixed `baseUrl`**: Changed from `/rugsafe-docs` to `/` — with a custom domain, the base must be root or all JS/CSS assets fail to load, causing a blank page
- **Fixed broken asset references**: favicon pointed to nonexistent `rugsafe_character_black_background.png`, social card pointed to nonexistent `rugsafe-social-card.jpg` — both now point to images that actually exist in `static/img/`
- **Fixed org/repo references**: Updated `organizationName`, `projectName`, `editUrl`, and GitHub links from `rugsafe/rugsafedocs` to `Rugsafe/rugsafe-docs`
- **Removed stray `docs/CNAME`**: Duplicate CNAME file inside the docs folder (the correct one is at repo root)

## Root Cause
The site was deploying successfully but rendering a blank page because `baseUrl: '/rugsafe-docs'` caused all static assets (JS, CSS) to be served from `/rugsafe-docs/assets/...` while the custom domain serves from `/`. The browser couldn't load any assets, so the page appeared blank.

## Test plan
- [ ] Verify GitHub Actions deploy succeeds
- [ ] Verify https://docs.rugsafe.io loads and renders the Docusaurus docs site
- [ ] Verify favicon and social card image load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)